### PR TITLE
do not wrap reqwest::Client in Arc, as it itself uses Arc internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voyager"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Matthias Seitz <matthias.seitz@outlook.de>"]
 edition = "2018"
 description = "Web crawler and scraper"

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use anyhow::Result;
@@ -191,7 +190,7 @@ type CrawlRequest<T> = Pin<Box<dyn Future<Output = Result<Response<T>>>>>;
 type RobotsTxtRequest = Pin<Box<dyn Future<Output = Result<RobotsData>>>>;
 
 pub struct AllowedDomain<T> {
-    client: Arc<reqwest::Client>,
+    client: reqwest::Client,
     /// Futures that eventually return a http response that is passed to the
     /// scraper
     in_progress_crawl_requests: Vec<CrawlRequest<T>>,
@@ -382,14 +381,14 @@ where
 pub struct AllowListConfig {
     pub delay: Option<RequestDelay>,
     pub respect_robots_txt: bool,
-    pub client: Arc<reqwest::Client>,
+    pub client: reqwest::Client,
     pub skip_non_successful_responses: bool,
     pub max_depth: usize,
     pub max_requests: usize,
 }
 
 pub struct BlockList<T> {
-    client: Arc<reqwest::Client>,
+    client: reqwest::Client,
     /// list of domains that are blocked
     blocked_domains: HashSet<String>,
     /// Futures that eventually return a http response that is passed to the
@@ -417,7 +416,7 @@ pub struct BlockList<T> {
 impl<T> BlockList<T> {
     pub fn new(
         blocked_domains: HashSet<String>,
-        client: Arc<reqwest::Client>,
+        client: reqwest::Client,
         respect_robots_txt: bool,
         skip_non_successful_responses: bool,
         max_depth: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ pub struct Crawler<T: Scraper> {
 impl<T: Scraper> Crawler<T> {
     /// Create a new crawler following the config
     pub fn new(config: CrawlerConfig) -> Self {
-        let client = config.client.unwrap_or_else(|| Default::default());
+        let client = config.client.unwrap_or_else(Default::default);
 
         let list = if config.allowed_domains.is_empty() {
             let block_list = BlockList::new(
@@ -612,7 +612,10 @@ impl CrawlerConfig {
 
     /// *NOTE* [`reqwest::Client`] already uses Arc under the hood, so
     /// it's preferable to just `clone` it and pass via [`Self::set_client`]
-    #[deprecated( since = "0.2", message = "You do not have to wrap the Client it in a `Arc` to reuse it, because it already uses an `Arc` internally. Users should instead use `set_client`instead."]
+    #[deprecated(
+        since = "0.2.0",
+        note = "You do not have to wrap the Client it in a `Arc` to reuse it, because it already uses an `Arc` internally. Users should instead use `set_client` instead."
+    )]
     pub fn with_shared_client(mut self, client: std::sync::Arc<reqwest::Client>) -> Self {
         self.client = Some(client.as_ref().clone());
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,6 +612,7 @@ impl CrawlerConfig {
 
     /// *NOTE* [`reqwest::Client`] already uses Arc under the hood, so
     /// it's preferable to just `clone` it and pass via [`Self::set_client`]
+    #[deprecated( since = "0.2", message = "You do not have to wrap the Client it in a `Arc` to reuse it, because it already uses an `Arc` internally. Users should instead use `set_client`instead."]
     pub fn with_shared_client(mut self, client: std::sync::Arc<reqwest::Client>) -> Self {
         self.client = Some(client.as_ref().clone());
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 mod domain;
@@ -270,7 +269,7 @@ pub struct Crawler<T: Scraper> {
     in_progress_crawl_requests: Vec<CrawlRequest<T::State>>,
     queued_results: VecDeque<CrawlResult<T>>,
     /// The client that issues all the requests
-    client: Arc<reqwest::Client>,
+    client: reqwest::Client,
     /// used to track the depth of submitted requests
     current_depth: usize,
     /// Either a list that only allows a set of domains or disallows a set of
@@ -290,14 +289,12 @@ pub struct Crawler<T: Scraper> {
 impl<T: Scraper> Crawler<T> {
     /// Create a new crawler following the config
     pub fn new(config: CrawlerConfig) -> Self {
-        let client = config
-            .client
-            .unwrap_or_else(|| Arc::new(Default::default()));
+        let client = config.client.unwrap_or_else(|| Default::default());
 
         let list = if config.allowed_domains.is_empty() {
             let block_list = BlockList::new(
                 config.disallowed_domains,
-                Arc::clone(&client),
+                client.clone(),
                 config.respect_robots_txt,
                 config.skip_non_successful_responses,
                 config.max_depth.unwrap_or(usize::MAX),
@@ -316,7 +313,7 @@ impl<T: Scraper> Crawler<T> {
                 let allow = AllowListConfig {
                     delay,
                     respect_robots_txt: config.respect_robots_txt,
-                    client: Arc::clone(&client),
+                    client: client.clone(),
                     skip_non_successful_responses: config.skip_non_successful_responses,
                     max_depth: config.max_depth.unwrap_or(usize::MAX),
                     max_requests,
@@ -367,11 +364,11 @@ where
     /// the scraper again
     pub fn crawl<TCrawlFunction, TCrawlFuture>(&mut self, fun: TCrawlFunction)
     where
-        TCrawlFunction: FnOnce(Arc<reqwest::Client>) -> TCrawlFuture,
+        TCrawlFunction: FnOnce(&reqwest::Client) -> TCrawlFuture,
         TCrawlFuture: Future<Output = Result<(reqwest::Response, Option<T::State>)>> + 'static,
     {
         let depth = self.current_depth + 1;
-        let fut = (fun)(Arc::clone(&self.client));
+        let fut = (fun)(&self.client);
         let fut = Box::pin(async move {
             let (mut resp, state) = fut.await?;
             let (status, url, headers) = response_info(&mut resp);
@@ -397,10 +394,10 @@ where
     /// returned once finished.
     pub fn complete<TCrawlFunction, TCrawlFuture>(&mut self, fun: TCrawlFunction)
     where
-        TCrawlFunction: FnOnce(Arc<reqwest::Client>) -> TCrawlFuture,
+        TCrawlFunction: FnOnce(&reqwest::Client) -> TCrawlFuture,
         TCrawlFuture: Future<Output = Result<Option<T::Output>>> + 'static,
     {
-        let fut = (fun)(Arc::clone(&self.client));
+        let fut = (fun)(&self.client);
         self.in_progress_complete_requests.push(Box::pin(fut))
     }
 
@@ -438,7 +435,7 @@ where
 
     /// The client that performs all request
     pub fn client(&self) -> &reqwest::Client {
-        self.client.as_ref()
+        &self.client
     }
 
     /// advance all requests
@@ -573,7 +570,7 @@ pub struct CrawlerConfig {
     // /// Delay a request
     // request_delay: Option<RequestDelay>,
     /// The client that will be used to send the requests
-    client: Option<Arc<reqwest::Client>>,
+    client: Option<reqwest::Client>,
 }
 
 impl Default for CrawlerConfig {
@@ -609,12 +606,14 @@ impl CrawlerConfig {
     }
 
     pub fn set_client(mut self, client: reqwest::Client) -> Self {
-        self.client = Some(Arc::new(client));
+        self.client = Some(client);
         self
     }
 
-    pub fn with_shared_client(mut self, client: Arc<reqwest::Client>) -> Self {
-        self.client = Some(client);
+    /// *NOTE* [`reqwest::Client`] already uses Arc under the hood, so
+    /// it's preferable to just `clone` it and pass via [`Self::set_client`]
+    pub fn with_shared_client(mut self, client: std::sync::Arc<reqwest::Client>) -> Self {
+        self.client = Some(client.as_ref().clone());
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,7 +614,7 @@ impl CrawlerConfig {
     /// it's preferable to just `clone` it and pass via [`Self::set_client`]
     #[deprecated(
         since = "0.2.0",
-        note = "You do not have to wrap the Client it in a `Arc` to reuse it, because it already uses an `Arc` internally. Users should instead use `set_client` instead."
+        note = "You do not have to wrap the Client it in a `Arc` to reuse it, because it already uses an `Arc` internally. Users should use `set_client` instead."
     )]
     pub fn with_shared_client(mut self, client: std::sync::Arc<reqwest::Client>) -> Self {
         self.client = Some(client.as_ref().clone());


### PR DESCRIPTION
Hello! Fist of all – thank you for your crate, I've been using it third time this week for my pet projects :)

I was reading `voyager` sources and noticed that you wrap `reqwest::Client` in an `Arc`. I've been doing it myself for some time, until I read thoroughly `reqwest` docs and noticed, that Client is [already][1] Arc-wrapped internaly.

If you are OK with it – in this PR I remove Arc-wrapping from voyager. 
There is also some questions about possibilities of breaking changes that I'd like to discuss, if you decide to merge this PR.

Thanks again,
Vlad :)

[1]: https://github.com/seanmonstar/reqwest/blob/master/src/async_impl/client.rs#L56-L63