### PR TITLE
feat: allow to set a default request delay for block list

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -421,7 +421,11 @@ impl<T> BlockList<T> {
         skip_non_successful_responses: bool,
         max_depth: usize,
         max_requests: usize,
+        request_delay: Option<RequestDelay>,
     ) -> Self {
+        let request_queue = request_delay
+            .map(RequestQueue::with_delay)
+            .unwrap_or_default();
         BlockList {
             client,
             blocked_domains,
@@ -431,7 +435,7 @@ impl<T> BlockList<T> {
             in_progress_robots_txt_crawl_hosts: Default::default(),
             respect_robots_txt,
             skip_non_successful_responses,
-            request_queue: Default::default(),
+            request_queue,
             max_depth,
             max_requests,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,7 @@ impl<T: Scraper> Crawler<T> {
                 config
                     .max_requests
                     .unwrap_or(CrawlerConfig::MAX_CONCURRENT_REQUESTS),
+                config.request_delay,
             );
             DomainListing::BlockList(block_list)
         } else {
@@ -567,6 +568,8 @@ pub struct CrawlerConfig {
     allowed_domains: HashMap<String, Option<RequestDelay>>,
     /// Domain blacklist
     disallowed_domains: HashSet<String>,
+    /// Default request delay, only applied when using `disallowed_domains`
+    request_delay: Option<RequestDelay>,
     /// respects the any restrictions set by the target host's
     /// robots.txt file. See <http://www.robotstxt.org/>` for more information.
     respect_robots_txt: bool,
@@ -584,6 +587,7 @@ impl Default for CrawlerConfig {
             skip_non_successful_responses: true,
             allowed_domains: Default::default(),
             disallowed_domains: Default::default(),
+            request_delay: Default::default(),
             respect_robots_txt: false,
             client: None,
         }
@@ -673,6 +677,11 @@ impl CrawlerConfig {
         for (domain, delay) in domains.into_iter() {
             self.allowed_domains.insert(domain.into(), Some(delay));
         }
+        self
+    }
+
+    pub fn set_delay(mut self, request_delay: RequestDelay) -> Self {
+        self.request_delay = Some(request_delay);
         self
     }
 


### PR DESCRIPTION
Add the option to set a request delay when using the block list. The function `set_delay` is exposed but cannot be used (since we don't have access to the DomainList). To avoid exposing it, a new parameter is added to CrawlerConfig to set the request delay of BlockList.

## Use case

We want to crawl a website with external URLs, but we don't know which domain will be crawled. So to avoid adding every potential domain to the allow list for the request delay, we want to set it globally using block list request delay.